### PR TITLE
Recursively scan local uses

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 26
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
-        "simple-git": "^3.27.0",
-        "yaml": "^2.7.0"
+        "simple-git": "^3.36.0",
+        "yaml": "^2.9.0"
       },
       "bin": {
         "gcu": "dist/index.js",
         "gha-check-updates": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^22.13.9",
+        "@types/node": "^26.1.1",
         "ts-node": "^10.9.2",
-        "typescript": "^5.8.2"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -74,6 +74,21 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
     },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -99,13 +114,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.13.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
-      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/acorn": {
@@ -180,14 +195,16 @@
       "license": "MIT"
     },
     "node_modules/simple-git": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.27.0.tgz",
-      "integrity": "sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==",
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.5"
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
       },
       "funding": {
         "type": "github",
@@ -239,9 +256,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -253,9 +270,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -266,15 +283,18 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gha-check-updates",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Check for outdated github actions.",
   "repository": "github:jkoenig134/gha-check-updates",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "simple-git": "^3.27.0",
-    "yaml": "^2.7.0"
+    "simple-git": "^3.36.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@types/node": "^22.13.9",
+    "@types/node": "^26.1.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.2"
+    "typescript": "^6.0.3"
   },
   "publishConfig": {
     "access": "public",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,171 +1,196 @@
 #!/usr/bin/env node
 
-const baseDir = process.argv[2] ?? process.cwd()
+const baseDir = process.argv[2] ?? process.cwd();
 
-import fs from "fs"
-import { simpleGit } from "simple-git"
-import { parse } from "yaml"
+import fs from 'node:fs';
+import { simpleGit } from 'simple-git';
+import { parse } from 'yaml';
 
 if (!fs.existsSync(`${baseDir}/.github/workflows`)) {
-  console.log("No .github/workflows directory in your current directory '${process.cwd()}'.")
-  process.exit(1)
+  console.log(
+    "No .github/workflows directory in your current directory '${process.cwd()}'.",
+  );
+  process.exit(1);
 }
 
-const basePath = `${baseDir}/.github/workflows`
+const basePath = `${baseDir}/.github/workflows`;
 
 function collectFiles(dir: string): string[] {
-  const result: string[] = []
+  const result: string[] = [];
 
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = `${dir}/${entry.name}`
+    const full = `${dir}/${entry.name}`;
 
     if (entry.isDirectory()) {
-      result.push(...collectFiles(full))
-      continue
+      result.push(...collectFiles(full));
+      continue;
     }
 
-    const name = entry.name.toLowerCase()
-    if (name.endsWith(".yml") || name.endsWith(".yaml")) {
-      result.push(full)
+    const name = entry.name.toLowerCase();
+    if (name.endsWith('.yml') || name.endsWith('.yaml')) {
+      result.push(full);
     }
   }
 
-  return result
+  return result;
 }
 
 function resolveLocalUses(uses: string): string | null {
-  const resolved = uses.startsWith("/") ? uses : `${baseDir}/${uses.replace(/^\.\//, "")}`
+  const resolved = uses.startsWith('/')
+    ? uses
+    : `${baseDir}/${uses.replace(/^\.\//, '')}`;
 
-  if (!fs.existsSync(resolved)) return null
+  if (!fs.existsSync(resolved)) return null;
 
   if (fs.statSync(resolved).isDirectory()) {
-    for (const name of ["action.yml", "action.yaml"]) {
-      const candidate = `${resolved}/${name}`
-      if (fs.existsSync(candidate)) return candidate
+    for (const name of ['action.yml', 'action.yaml']) {
+      const candidate = `${resolved}/${name}`;
+      if (fs.existsSync(candidate)) return candidate;
     }
-    return null
+    return null;
   }
 
-  return resolved
+  return resolved;
 }
 
 function usesFromSteps(steps: any[] | undefined): string[] {
-  return (steps ?? []).filter((s: any) => s?.uses).map((s: any) => s.uses)
+  return (steps ?? []).filter((s: any) => s?.uses).map((s: any) => s.uses);
 }
 
 function getUsesDeclarations(yaml: any): string[] {
-  const uses: string[] = []
+  const uses: string[] = [];
 
   for (const job of Object.values(yaml?.jobs ?? {}) as any[]) {
-    if (job?.uses) uses.push(job.uses)
-    uses.push(...usesFromSteps(job?.steps))
+    if (job?.uses) uses.push(job.uses);
+    uses.push(...usesFromSteps(job?.steps));
   }
 
   // composite actions
-  uses.push(...usesFromSteps(yaml?.runs?.steps))
+  uses.push(...usesFromSteps(yaml?.runs?.steps));
 
-  return uses
+  return uses;
 }
 
-const visited = new Set<string>()
-const files = collectFiles(basePath)
+const visited = new Set<string>();
+const files = collectFiles(basePath);
 
 while (files.length > 0) {
-  const path = files.shift()!
+  const path = files.shift()!;
 
-  if (visited.has(path)) continue
-  visited.add(path)
+  if (visited.has(path)) continue;
+  visited.add(path);
 
-  const content = fs.readFileSync(path, "utf8")
-  const yaml = parse(content)
+  const content = fs.readFileSync(path, 'utf8');
+  const yaml = parse(content);
 
-  const uniqueUsesDeclarations: string[] = [...new Set(getUsesDeclarations(yaml))]
+  const uniqueUsesDeclarations: string[] = [
+    ...new Set(getUsesDeclarations(yaml)),
+  ];
 
-  const notUpToDates = []
+  const notUpToDates = [];
 
   for (const usesDeclaration of uniqueUsesDeclarations) {
-    if (usesDeclaration.startsWith("./") || usesDeclaration.startsWith("../") || usesDeclaration.startsWith("/")) {
-      const resolved = resolveLocalUses(usesDeclaration)
-      if (resolved && !visited.has(resolved)) files.push(resolved)
-      continue
+    if (
+      usesDeclaration.startsWith('./') ||
+      usesDeclaration.startsWith('../') ||
+      usesDeclaration.startsWith('/')
+    ) {
+      const resolved = resolveLocalUses(usesDeclaration);
+      if (resolved && !visited.has(resolved)) files.push(resolved);
+      continue;
     }
 
-    if (usesDeclaration.startsWith("docker://") || !usesDeclaration.includes("@")) {
-      continue
+    if (
+      usesDeclaration.startsWith('docker://') ||
+      !usesDeclaration.includes('@')
+    ) {
+      continue;
     }
 
-    const split = usesDeclaration.split("@")
-    const repo = split[0]
-    const version = split[1]
+    const split = usesDeclaration.split('@');
+    const repo = split[0];
+    const version = split[1];
 
-    const safeRepo = repo.split("/").slice(0, 2).join("/")
+    const safeRepo = repo.split('/').slice(0, 2).join('/');
 
     const tagsOutput = await simpleGit({
-      config: ["versionsort.suffix=-"],
-    }).listRemote(["--tags", "--sort=v:refname", `https://github.com/${safeRepo}.git`])
+      config: ['versionsort.suffix=-'],
+    }).listRemote([
+      '--tags',
+      '--sort=v:refname',
+      `https://github.com/${safeRepo}.git`,
+    ]);
 
     const tags = tagsOutput
-      .split("\n")
-      .map((v: string) => v.split("refs/tags/")[1])
-      .filter((v: string) => !!v)
+      .split('\n')
+      .map((v: string) => v.split('refs/tags/')[1])
+      .filter((v: string) => !!v);
 
-    const tagsByTagLengths: Record<number, string[] | undefined> = tags.reduce((acc: any, v: string) => {
-      const length = v.length
-      if (!acc[length]) {
-        acc[length] = []
-      }
+    const tagsByTagLengths: Record<number, string[] | undefined> = tags.reduce(
+      (acc: any, v: string) => {
+        const length = v.length;
+        if (!acc[length]) {
+          acc[length] = [];
+        }
 
-      acc[length].push(v)
-      return acc
-    }, {})
+        acc[length].push(v);
+        return acc;
+      },
+      {},
+    );
 
-    const single = tags.filter((v) => v.length === 2)
-    const lastSingle = single[single.length - 1]
+    const single = tags.filter((v) => v.length === 2);
+    const lastSingle = single[single.length - 1];
 
     const full = tags.filter((v) => {
       const match = v.match(
-        /^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
-      )
+        /^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/,
+      );
 
-      if (!match) return false
+      if (!match) return false;
 
-      return match.length > 0
-    })
-    const lastFull = full[full.length - 1]
+      return match.length > 0;
+    });
+    const lastFull = full[full.length - 1];
 
     if (!lastSingle && !lastFull) {
-      const tagsWithCorrectLength = tagsByTagLengths[version.length]
+      const tagsWithCorrectLength = tagsByTagLengths[version.length];
       if (tagsWithCorrectLength?.length) {
-        const versionToCompare = tagsWithCorrectLength[tagsWithCorrectLength.length - 1]
+        const versionToCompare =
+          tagsWithCorrectLength[tagsWithCorrectLength.length - 1];
         if (versionToCompare !== version) {
           notUpToDates.push(
             `  Action '${usesDeclaration}' has a newer version available: '${versionToCompare}'.${
-              lastFull || lastSingle ? ` You can also upgrade to '${lastSingle}' or '${lastFull}'.` : ""
-            }`
-          )
+              lastFull || lastSingle
+                ? ` You can also upgrade to '${lastSingle}' or '${lastFull}'.`
+                : ''
+            }`,
+          );
         }
 
-        continue
+        continue;
       } else {
         notUpToDates.push(
-          `  Action '${usesDeclaration}' could not be checked. You can check available versions yourself: https://github.com/${repo}/tags`
-        )
-        continue
+          `  Action '${usesDeclaration}' could not be checked. You can check available versions yourself: https://github.com/${repo}/tags`,
+        );
+        continue;
       }
     }
 
-    const versionToCompare = version.length === 2 ? lastSingle : lastFull
+    const versionToCompare = version.length === 2 ? lastSingle : lastFull;
 
     if (versionToCompare !== version) {
       const latestVersions = [lastSingle, lastFull]
-        .filter((v) => typeof v !== "undefined")
+        .filter((v) => typeof v !== 'undefined')
         .map((v) => `'${v}'`)
-        .join(" or ")
+        .join(' or ');
 
-      notUpToDates.push(`  Action '${usesDeclaration}' has a newer version available: ${latestVersions}.`)
+      notUpToDates.push(
+        `  Action '${usesDeclaration}' has a newer version available: ${latestVersions}.`,
+      );
     }
   }
 
-  console.log(`Checked ${path} ${notUpToDates.length ? "✗" : "✓"}`)
-  console.log(notUpToDates.join("\n"))
+  console.log(`Checked ${path} ${notUpToDates.length ? '✗' : '✓'}`);
+  console.log(notUpToDates.join('\n'));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,41 +153,53 @@ while (files.length > 0) {
     });
     const lastFull = full[full.length - 1];
 
+    const tagsWithCorrectLength = tagsByTagLengths[version.length];
+    const lengthMatch = tagsWithCorrectLength?.length
+      ? tagsWithCorrectLength[tagsWithCorrectLength.length - 1]
+      : undefined;
+
     if (!lastSingle && !lastFull) {
-      const tagsWithCorrectLength = tagsByTagLengths[version.length];
-      if (tagsWithCorrectLength?.length) {
-        const versionToCompare =
-          tagsWithCorrectLength[tagsWithCorrectLength.length - 1];
-        if (versionToCompare !== version) {
+      if (lengthMatch) {
+        if (lengthMatch !== version) {
           notUpToDates.push(
-            `  Action '${usesDeclaration}' has a newer version available: '${versionToCompare}'.${
-              lastFull || lastSingle
-                ? ` You can also upgrade to '${lastSingle}' or '${lastFull}'.`
-                : ''
-            }`,
+            `  Action '${usesDeclaration}' has a newer version available: '${lengthMatch}'.`,
           );
         }
 
         continue;
-      } else {
-        notUpToDates.push(
-          `  Action '${usesDeclaration}' could not be checked. You can check available versions yourself: https://github.com/${repo}/tags`,
-        );
-        continue;
       }
+
+      notUpToDates.push(
+        `  Action '${usesDeclaration}' could not be checked. You can check available versions yourself: https://github.com/${repo}/tags`,
+      );
+      continue;
     }
 
     const versionToCompare = version.length === 2 ? lastSingle : lastFull;
 
     if (versionToCompare !== version) {
-      const latestVersions = [lastSingle, lastFull]
-        .filter((v) => typeof v !== 'undefined')
-        .map((v) => `'${v}'`)
-        .join(' or ');
+      // Prefer same-length tag as primary; surface major/full tags as alternatives
+      if (lengthMatch && lengthMatch !== version) {
+        const also = [lastSingle, lastFull]
+          .filter((v) => typeof v !== 'undefined' && v !== lengthMatch)
+          .map((v) => `'${v}'`)
+          .join(' or ');
 
-      notUpToDates.push(
-        `  Action '${usesDeclaration}' has a newer version available: ${latestVersions}.`,
-      );
+        notUpToDates.push(
+          `  Action '${usesDeclaration}' has a newer version available: '${lengthMatch}'.${
+            also ? ` You can also upgrade to ${also}.` : ''
+          }`,
+        );
+      } else {
+        const latestVersions = [lastSingle, lastFull]
+          .filter((v) => typeof v !== 'undefined')
+          .map((v) => `'${v}'`)
+          .join(' or ');
+
+        notUpToDates.push(
+          `  Action '${usesDeclaration}' has a newer version available: ${latestVersions}.`,
+        );
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,181 +1,161 @@
 #!/usr/bin/env node
 
-const baseDir = process.argv[2] ?? process.cwd();
+const baseDir = process.argv[2] ?? process.cwd()
 
-import fs from 'node:fs';
-import { simpleGit } from 'simple-git';
-import { parse } from 'yaml';
+import fs from "node:fs"
+import { simpleGit } from "simple-git"
+import { parse } from "yaml"
 
 if (!fs.existsSync(`${baseDir}/.github/workflows`)) {
-  console.log(
-    "No .github/workflows directory in your current directory '${process.cwd()}'.",
-  );
-  process.exit(1);
+  console.log("No .github/workflows directory in your current directory '${process.cwd()}'.")
+  process.exit(1)
 }
 
-const basePath = `${baseDir}/.github/workflows`;
+const basePath = `${baseDir}/.github/workflows`
 
 function collectFiles(dir: string): string[] {
-  const result: string[] = [];
+  const result: string[] = []
 
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = `${dir}/${entry.name}`;
+    const full = `${dir}/${entry.name}`
 
     if (entry.isDirectory()) {
-      result.push(...collectFiles(full));
-      continue;
+      result.push(...collectFiles(full))
+      continue
     }
 
-    const name = entry.name.toLowerCase();
-    if (name.endsWith('.yml') || name.endsWith('.yaml')) {
-      result.push(full);
+    const name = entry.name.toLowerCase()
+    if (name.endsWith(".yml") || name.endsWith(".yaml")) {
+      result.push(full)
     }
   }
 
-  return result;
+  return result
 }
 
 function resolveLocalUses(uses: string): string | null {
-  const resolved = uses.startsWith('/')
-    ? uses
-    : `${baseDir}/${uses.replace(/^\.\//, '')}`;
+  const resolved = uses.startsWith("/") ? uses : `${baseDir}/${uses.replace(/^\.\//, "")}`
 
-  if (!fs.existsSync(resolved)) return null;
+  if (!fs.existsSync(resolved)) return null
 
   if (fs.statSync(resolved).isDirectory()) {
-    for (const name of ['action.yml', 'action.yaml']) {
-      const candidate = `${resolved}/${name}`;
-      if (fs.existsSync(candidate)) return candidate;
+    for (const name of ["action.yml", "action.yaml"]) {
+      const candidate = `${resolved}/${name}`
+      if (fs.existsSync(candidate)) return candidate
     }
-    return null;
+    return null
   }
 
-  return resolved;
+  return resolved
 }
 
 function usesFromSteps(steps: any[] | undefined): string[] {
-  return (steps ?? []).filter((s: any) => s?.uses).map((s: any) => s.uses);
+  return (steps ?? []).filter((s: any) => s?.uses).map((s: any) => s.uses)
 }
 
 function getUsesDeclarations(yaml: any): string[] {
-  const uses: string[] = [];
+  const uses: string[] = []
 
   for (const job of Object.values(yaml?.jobs ?? {}) as any[]) {
-    if (job?.uses) uses.push(job.uses);
-    uses.push(...usesFromSteps(job?.steps));
+    if (job?.uses) uses.push(job.uses)
+    uses.push(...usesFromSteps(job?.steps))
   }
 
   // composite actions
-  uses.push(...usesFromSteps(yaml?.runs?.steps));
+  uses.push(...usesFromSteps(yaml?.runs?.steps))
 
-  return uses;
+  return uses
 }
 
-const visited = new Set<string>();
-const files = collectFiles(basePath);
+const visited = new Set<string>()
+const files = collectFiles(basePath)
 
 while (files.length > 0) {
-  const path = files.shift()!;
+  const path = files.shift()!
 
-  if (visited.has(path)) continue;
-  visited.add(path);
+  if (visited.has(path)) continue
+  visited.add(path)
 
-  const content = fs.readFileSync(path, 'utf8');
-  const yaml = parse(content);
+  const content = fs.readFileSync(path, "utf8")
+  const yaml = parse(content)
 
-  const uniqueUsesDeclarations: string[] = [
-    ...new Set(getUsesDeclarations(yaml)),
-  ];
+  const uniqueUsesDeclarations: string[] = [...new Set(getUsesDeclarations(yaml))]
 
-  const notUpToDates = [];
+  const notUpToDates = []
 
   for (const usesDeclaration of uniqueUsesDeclarations) {
-    if (
-      usesDeclaration.startsWith('./') ||
-      usesDeclaration.startsWith('../') ||
-      usesDeclaration.startsWith('/')
-    ) {
-      const resolved = resolveLocalUses(usesDeclaration);
-      if (resolved && !visited.has(resolved)) files.push(resolved);
-      continue;
+    if (usesDeclaration.startsWith("./") || usesDeclaration.startsWith("../") || usesDeclaration.startsWith("/")) {
+      const resolved = resolveLocalUses(usesDeclaration)
+      if (resolved && !visited.has(resolved)) files.push(resolved)
+      continue
     }
 
-    if (
-      usesDeclaration.startsWith('docker://') ||
-      !usesDeclaration.includes('@')
-    ) {
-      continue;
+    if (usesDeclaration.startsWith("docker://") || !usesDeclaration.includes("@")) {
+      continue
     }
 
-    const split = usesDeclaration.split('@');
-    const repo = split[0];
-    const version = split[1];
+    const split = usesDeclaration.split("@")
+    const repo = split[0]
+    const version = split[1]
 
-    const safeRepo = repo.split('/').slice(0, 2).join('/');
+    const safeRepo = repo.split("/").slice(0, 2).join("/")
 
     const tagsOutput = await simpleGit({
-      config: ['versionsort.suffix=-'],
-    }).listRemote([
-      '--tags',
-      '--sort=v:refname',
-      `https://github.com/${safeRepo}.git`,
-    ]);
+      config: ["versionsort.suffix=-"],
+    }).listRemote(["--tags", "--sort=v:refname", `https://github.com/${safeRepo}.git`])
 
     const tags = tagsOutput
-      .split('\n')
-      .map((v: string) => v.split('refs/tags/')[1])
-      .filter((v: string) => !!v);
+      .split("\n")
+      .map((v: string) => v.split("refs/tags/")[1])
+      .filter((v: string) => !!v)
 
-    const tagsByTagLengths: Record<number, string[] | undefined> = tags.reduce(
-      (acc: any, v: string) => {
-        const length = v.length;
-        if (!acc[length]) {
-          acc[length] = [];
-        }
+    const tagsByTagLengths: Record<number, string[] | undefined> = tags.reduce((acc: any, v: string) => {
+      const length = v.length
+      if (!acc[length]) {
+        acc[length] = []
+      }
 
-        acc[length].push(v);
-        return acc;
-      },
-      {},
-    );
+      acc[length].push(v)
+      return acc
+    }, {})
 
-    const single = tags.filter((v) => v.length === 2);
-    const lastSingle = single[single.length - 1];
+    const single = tags.filter((v) => v.length === 2)
+    const lastSingle = single[single.length - 1]
 
     const full = tags.filter((v) => {
       const match = v.match(
-        /^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/,
-      );
+        /^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
+      )
 
-      if (!match) return false;
+      if (!match) return false
 
-      return match.length > 0;
-    });
-    const lastFull = full[full.length - 1];
+      return match.length > 0
+    })
+    const lastFull = full[full.length - 1]
 
-    const tagsWithCorrectLength = tagsByTagLengths[version.length];
+    const tagsWithCorrectLength = tagsByTagLengths[version.length]
     const lengthMatch = tagsWithCorrectLength?.length
       ? tagsWithCorrectLength[tagsWithCorrectLength.length - 1]
-      : undefined;
+      : undefined
 
     if (!lastSingle && !lastFull) {
       if (lengthMatch) {
         if (lengthMatch !== version) {
           notUpToDates.push(
-            `  Action '${usesDeclaration}' has a newer version available: '${lengthMatch}'.`,
-          );
+            `  Action '${usesDeclaration}' has a newer version available: '${lengthMatch}'.`
+          )
         }
 
-        continue;
+        continue
       }
 
       notUpToDates.push(
-        `  Action '${usesDeclaration}' could not be checked. You can check available versions yourself: https://github.com/${repo}/tags`,
-      );
-      continue;
+        `  Action '${usesDeclaration}' could not be checked. You can check available versions yourself: https://github.com/${repo}/tags`
+      )
+      continue
     }
 
-    const versionToCompare = version.length === 2 ? lastSingle : lastFull;
+    const versionToCompare = version.length === 2 ? lastSingle : lastFull
 
     if (versionToCompare !== version) {
       // Prefer same-length tag as primary; surface major/full tags as alternatives
@@ -183,26 +163,26 @@ while (files.length > 0) {
         const also = [lastSingle, lastFull]
           .filter((v) => v !== undefined && v !== lengthMatch)
           .map((v) => `'${v}'`)
-          .join(' or ');
+          .join(" or ")
 
         notUpToDates.push(
           `  Action '${usesDeclaration}' has a newer version available: '${lengthMatch}'.${
-            also ? ` You can also upgrade to ${also}.` : ''
-          }`,
-        );
+            also ? ` You can also upgrade to ${also}.` : ""
+          }`
+        )
       } else {
         const latestVersions = [lastSingle, lastFull]
           .filter((v) => v !== undefined)
           .map((v) => `'${v}'`)
-          .join(' or ');
+          .join(" or ")
 
         notUpToDates.push(
-          `  Action '${usesDeclaration}' has a newer version available: ${latestVersions}.`,
-        );
+          `  Action '${usesDeclaration}' has a newer version available: ${latestVersions}.`
+        )
       }
     }
   }
 
-  console.log(`Checked ${path} ${notUpToDates.length ? '✗' : '✓'}`);
-  console.log(notUpToDates.join('\n'));
+  console.log(`Checked ${path} ${notUpToDates.length ? "✗" : "✓"}`)
+  console.log(notUpToDates.join("\n"))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,40 +6,94 @@ import fs from "fs"
 import { simpleGit } from "simple-git"
 import { parse } from "yaml"
 
-if (!fs.existsSync(".github/workflows")) {
+if (!fs.existsSync(`${baseDir}/.github/workflows`)) {
   console.log("No .github/workflows directory in your current directory '${process.cwd()}'.")
   process.exit(1)
 }
 
 const basePath = `${baseDir}/.github/workflows`
 
-// find all files in the .github/workflows directory using nodejs fs
-const files = fs.readdirSync(basePath)
+function collectFiles(dir: string): string[] {
+  const result: string[] = []
 
-for (const file of files) {
-  const path = `${basePath}/${file}`
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = `${dir}/${entry.name}`
+
+    if (entry.isDirectory()) {
+      result.push(...collectFiles(full))
+      continue
+    }
+
+    const name = entry.name.toLowerCase()
+    if (name.endsWith(".yml") || name.endsWith(".yaml")) {
+      result.push(full)
+    }
+  }
+
+  return result
+}
+
+function resolveLocalUses(uses: string): string | null {
+  const resolved = uses.startsWith("/") ? uses : `${baseDir}/${uses.replace(/^\.\//, "")}`
+
+  if (!fs.existsSync(resolved)) return null
+
+  if (fs.statSync(resolved).isDirectory()) {
+    for (const name of ["action.yml", "action.yaml"]) {
+      const candidate = `${resolved}/${name}`
+      if (fs.existsSync(candidate)) return candidate
+    }
+    return null
+  }
+
+  return resolved
+}
+
+function usesFromSteps(steps: any[] | undefined): string[] {
+  return (steps ?? []).filter((s: any) => s?.uses).map((s: any) => s.uses)
+}
+
+function getUsesDeclarations(yaml: any): string[] {
+  const uses: string[] = []
+
+  for (const job of Object.values(yaml?.jobs ?? {}) as any[]) {
+    if (job?.uses) uses.push(job.uses)
+    uses.push(...usesFromSteps(job?.steps))
+  }
+
+  // composite actions
+  uses.push(...usesFromSteps(yaml?.runs?.steps))
+
+  return uses
+}
+
+const visited = new Set<string>()
+const files = collectFiles(basePath)
+
+while (files.length > 0) {
+  const path = files.shift()!
+
+  if (visited.has(path)) continue
+  visited.add(path)
 
   const content = fs.readFileSync(path, "utf8")
   const yaml = parse(content)
 
-  const jobs = yaml.jobs
-  if (!jobs) {
-    console.log(`No jobs in ${path}`)
-    continue
-  }
-
-  const jobsValues = Object.values(jobs)
-  const usesDeclarations = jobsValues
-    .map((v: any) => v.steps)
-    .flatMap((v: any) => v)
-    .filter((v: any) => v.uses)
-    .map((v: any) => v.uses)
-
-  const uniqueUsesDeclarations: string[] = [...new Set(usesDeclarations)]
+  const uniqueUsesDeclarations: string[] = [...new Set(getUsesDeclarations(yaml))]
 
   const notUpToDates = []
 
   for (const usesDeclaration of uniqueUsesDeclarations) {
+    if (usesDeclaration.startsWith("./") || usesDeclaration.startsWith("../") || usesDeclaration.startsWith("/")) {
+      const resolved = resolveLocalUses(usesDeclaration)
+      if (resolved && !visited.has(resolved)) files.push(resolved)
+      continue
+    }
+
+    if (usesDeclaration.startsWith("docker://") || !usesDeclaration.includes("@")) {
+      continue
+    }
+
     const split = usesDeclaration.split("@")
     const repo = split[0]
     const version = split[1]

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,12 @@ import fs from "node:fs"
 import { simpleGit } from "simple-git"
 import { parse } from "yaml"
 
-if (!fs.existsSync(`${baseDir}/.github/workflows`)) {
+const basePath = `${baseDir}/.github/workflows`;
+
+if (!fs.existsSync(basePath)) {
   console.log("No .github/workflows directory in your current directory '${process.cwd()}'.")
   process.exit(1)
 }
-
-const basePath = `${baseDir}/.github/workflows`
 
 function collectFiles(dir: string): string[] {
   const result: string[] = []

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ while (files.length > 0) {
       // Prefer same-length tag as primary; surface major/full tags as alternatives
       if (lengthMatch && lengthMatch !== version) {
         const also = [lastSingle, lastFull]
-          .filter((v) => typeof v !== 'undefined' && v !== lengthMatch)
+          .filter((v) => v !== undefined && v !== lengthMatch)
           .map((v) => `'${v}'`)
           .join(' or ');
 
@@ -192,7 +192,7 @@ while (files.length > 0) {
         );
       } else {
         const latestVersions = [lastSingle, lastFull]
-          .filter((v) => typeof v !== 'undefined')
+          .filter((v) => v !== undefined)
           .map((v) => `'${v}'`)
           .join(' or ');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
         "declaration": false,
-        "downlevelIteration": true,
         "emitDecoratorMetadata": false,
         "esModuleInterop": true,
         "experimentalDecorators": true,
@@ -15,12 +14,16 @@
         "moduleResolution": "nodenext",
         "noImplicitReturns": true,
         "outDir": "dist",
+        "rootDir": "./src",
         "resolveJsonModule": true,
         "sourceMap": false,
         "strict": true,
         "strictNullChecks": true,
         "strictPropertyInitialization": false,
         "target": "es2021",
+        "types": [
+            "node"
+        ],
         "typeRoots": [
             "./node_modules/@types"
         ]


### PR DESCRIPTION
* Fixes #5 by not just ignoring local `uses` but following them and checking them too.

* Fixed a bug where `You can also upgrade to` string path was unreachable

* Fixed some warnings caught by sonarqube

* Bumped packages 

Let me know if you prefer I split these into separate PRs